### PR TITLE
Disable Panther NUC DHCP Server

### DIFF
--- a/robots/panther/custom_config.sh
+++ b/robots/panther/custom_config.sh
@@ -9,6 +9,11 @@ cp ${CONFIG_FILES_PATH}/files/chrony.conf /etc/chrony/chrony.conf
 cp ${CONFIG_FILES_PATH}/files/chrony.service /lib/systemd/system/chrony.service
 cp ${CONFIG_FILES_PATH}/files/hwclock-set /lib/udev/hwclock-set
 
+# Disable dhcp-server
+sudo service isc-dhcp-server stop
+sudo systemctl disable isc-dhcp-server
+sudo systemctl daemon-reload
+
 # Setup envs
 echo "ROS_IP=10.15.20.3" >> /etc/environment
 echo "ROS_MASTER_URI=http://10.15.20.2:11311" >> /etc/environment


### PR DESCRIPTION
# Description

In this pull request, I address the issue where the DHCP server on the NUC is enabled (as introduced in earlier commits), causing all devices on the Panther robot to connect to this server instead of the Rutix router. The proposed changes rectify this problem by adjusting the configuration to ensure that devices correctly connect to the intended router, enhancing network functionality and stability.