### PR TITLE
Add execution rights for robot configs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -25,6 +25,9 @@ do
 
     # Copy the file to /usr/lib/husarion with "subfolder.sh" name
     cp "$file" "/usr/lib/husarion/custom_config_${dirname}.sh"
+
+    # Grant execution rights to a file
+    chmod +x /usr/lib/husarion/custom_config_${dirname}.sh
 done
 
 # Copy the setup_robot_configuration script to /usr/local/sbin/


### PR DESCRIPTION
## Motivation

Panther's robot config installed on Husarion OS was missing execution rights.

## Changes

- Add `chmod` while copying robot configs to ensure all robot configs are executable. 